### PR TITLE
fix stale asset/data caching and support legacy menu JSON

### DIFF
--- a/web/mahlzeit.js
+++ b/web/mahlzeit.js
@@ -1,19 +1,39 @@
-const enableServiceWorker = false;
+const enableServiceWorker = true;
 
 if (enableServiceWorker && "serviceWorker" in navigator) {
-  try {
-    const registration = navigator.serviceWorker.register("service-worker.js");
+  let refreshing = false;
 
-    if (registration.installing) {
-      console.log("Service worker installing");
-    } else if (registration.waiting) {
-      console.log("Service worker installed");
-    } else if (registration.active) {
-      console.log("Service worker active");
+  navigator.serviceWorker.addEventListener("controllerchange", () => {
+    if (refreshing) return;
+    refreshing = true;
+    window.location.reload();
+  });
+
+  window.addEventListener("load", async () => {
+    try {
+      const registration = await navigator.serviceWorker.register("service-worker.js", {
+        updateViaCache: "none"
+      });
+      console.log("Service worker registered");
+
+      if (registration.installing) {
+        console.log("Service worker installing");
+      } else if (registration.waiting) {
+        console.log("Service worker waiting");
+      } else if (registration.active) {
+        console.log("Service worker active");
+      }
+
+      registration.addEventListener("updatefound", () => {
+        console.log("Service worker update found");
+      });
+
+      // Check for updated worker on each page load.
+      await registration.update();
+    } catch (error) {
+      console.error("Service worker registration failed", error);
     }
-  } catch (error) {
-    console.error(`Registration failed with ${error}`);
-  }
+  });
 }
 
 const mzCarouselElement = document.querySelector('#mzCarousel')
@@ -22,6 +42,15 @@ const carousel = new bootstrap.Carousel(mzCarouselElement, {
 });
 
 const dayNames = ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'];
+const isoWeekdayByName = {
+  Montag: 1,
+  Dienstag: 2,
+  Mittwoch: 3,
+  Donnerstag: 4,
+  Freitag: 5,
+  Samstag: 6,
+  Sonntag: 7
+};
 
 var now = new XDate();
 var today = XDate.today();
@@ -29,8 +58,21 @@ if (now.getHours() >= 13) { today.addDays(1) };
 
 $(document).ready(function() {
   var template = $("#mzCarousel .carousel-item.active").detach().removeClass("active");
+  var menuUrl = `./mahlzeit_v2.json?t=${Date.now()}`;
 
-  $.getJSON( "./mahlzeit_v2.json", function( data ) {
+  fetch(menuUrl, {
+    cache: "no-store",
+    headers: { "Cache-Control": "no-cache" }
+  })
+  .then(function(response) {
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    return response.json();
+  })
+  .then(function( data ) {
+    data = normalizeMenuData(data);
+
     $.each( data, function( i, day ) {
       ci = renderDay(day, template.clone());
       ci.appendTo("#mzCarousel .carousel-inner");
@@ -40,12 +82,66 @@ $(document).ready(function() {
     if (!$("#mzCarousel .carousel-item").hasClass("active")) {
       template.clone().addClass("active").appendTo("#mzCarousel .carousel-inner").find(".mz-day").text("Sorry, no data.");
     }
-  }).fail(function(){
+  }).catch(function(error){
+    console.error("Could not load menu JSON", error);
     template.addClass("active");
     template.find(".mz-day").text("Oops! Could not load the menu!");
     template.appendTo("#mzCarousel .carousel-inner");
   });
 });
+
+function normalizeMenuData(data) {
+  if (Array.isArray(data)) {
+    return data;
+  }
+
+  if (data && typeof data === "object") {
+    const normalized = [];
+
+    $.each(data, function(weekKey, daysByName) {
+      const match = /^(\d{4})W(\d{2})$/.exec(weekKey);
+      if (!match || !daysByName || typeof daysByName !== "object") {
+        return;
+      }
+
+      const year = Number(match[1]);
+      const week = Number(match[2]);
+
+      $.each(daysByName, function(dayName, dishesByCategory) {
+        const isoWeekday = isoWeekdayByName[dayName];
+        if (!isoWeekday || !dishesByCategory || typeof dishesByCategory !== "object") {
+          return;
+        }
+
+        normalized.push({
+          date: isoWeekDateToIsoString(year, week, isoWeekday),
+          menu: Object.values(dishesByCategory)
+        });
+      });
+    });
+
+    normalized.sort(function(a, b) {
+      return a.date.localeCompare(b.date);
+    });
+
+    return normalized;
+  }
+
+  return [];
+}
+
+function isoWeekDateToIsoString(year, week, isoWeekday) {
+  // ISO week 1 is the week containing Jan 4; Monday is day 1.
+  const jan4 = new Date(Date.UTC(year, 0, 4));
+  const jan4Weekday = jan4.getUTCDay() || 7;
+  const mondayOfWeek1 = new Date(jan4);
+  mondayOfWeek1.setUTCDate(jan4.getUTCDate() - jan4Weekday + 1);
+
+  const target = new Date(mondayOfWeek1);
+  target.setUTCDate(mondayOfWeek1.getUTCDate() + (week - 1) * 7 + (isoWeekday - 1));
+
+  return target.toISOString().slice(0, 10);
+}
 
 function tagPrice(elem) {
   const regex = /\b([0-9,]+&nbsp;€)/u;


### PR DESCRIPTION
- rework service worker caching strategy in web/service-worker.js
- bump cache version to mahlzeit-v2.1
- precache app shell via shared PRECACHE_RESOURCES
- activate new SW faster with skipWaiting() and clients.claim()
- delete old caches on activate
- switch same-origin requests to network-first (fallback to cache)
- bypass SW caching for mahlzeit_v2.json (cache: no-store)
- fix fetch handler bugs (undeclared vars / wrong request reference)
- cache only successful network responses
- harden SW registration in web/mahlzeit.js
- use async navigator.serviceWorker.register(...)
- set updateViaCache: "none" and trigger registration.update() on load
- reload page on controllerchange when updated SW takes control
- replace jQuery JSON loading with fetch() + cache-busting query param
- request menu JSON with cache: "no-store" and explicit error handling
- add runtime normalization for legacy week-keyed JSON format
- convert YYYYWww + weekday names into v2-compatible { date, menu } entries